### PR TITLE
[FEATURE] Introduce a new Service class for handling the password reset procedure

### DIFF
--- a/Classes/Mvc/View/StandaloneView.php
+++ b/Classes/Mvc/View/StandaloneView.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace PAGEmachine\Hairu\Mvc\View;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class StandaloneView extends \TYPO3\CMS\Fluid\View\TemplateView {
+
+  public function __construct($controllerObjectName = 'PAGEmachine\Hairu\Controller\AuthenticationController') {
+    parent::__construct();
+
+    /* @var $request \TYPO3\CMS\Extbase\Mvc\Web\Request */
+    $request = $this->objectManager->get('TYPO3\CMS\Extbase\Mvc\Web\Request');
+    $request->setRequestURI(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
+    $request->setBaseURI(GeneralUtility::getIndpEnv('TYPO3_SITE_URL'));
+    // Set correct extension context
+    $request->setControllerObjectName($controllerObjectName);
+    /** @var $controllerContext \TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext */
+    $controllerContext = $this->objectManager->get('TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext');
+    $controllerContext->setRequest($request);
+    $uriBuilder = $this->objectManager->get('TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder');
+    $uriBuilder->setRequest($request);
+    $controllerContext->setUriBuilder($uriBuilder);
+    /** @var $renderingContext \TYPO3\CMS\Fluid\Core\Rendering\RenderingContext */
+    $renderingContext = $this->objectManager->get('TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface');
+    $renderingContext->setControllerContext($controllerContext);
+    $this->setRenderingContext($renderingContext);
+  }
+
+  // From extbase ActionController
+
+  /**
+   * Handles the path resolving for *rootPath(s)
+   * singular one is deprecated and will be removed two versions after 6.2
+   * if deprecated setting is found, use it as the very last fallback target
+   *
+   * numerical arrays get ordered by key ascending
+   *
+   * @param array $extbaseFrameworkConfiguration
+   * @param string $setting parameter name from TypoScript
+   * @param string $deprecatedSetting parameter name from TypoScript
+   *
+   * @return array
+   */
+  protected function getViewProperty($extbaseFrameworkConfiguration, $setting, $deprecatedSetting = '') {
+    $values = array();
+
+    if (
+            !empty($extbaseFrameworkConfiguration['view'][$setting]) && is_array($extbaseFrameworkConfiguration['view'][$setting])
+    ) {
+      $values = \TYPO3\CMS\Extbase\Utility\ArrayUtility::sortArrayWithIntegerKeys($extbaseFrameworkConfiguration['view'][$setting]);
+      $values = array_reverse($values, TRUE);
+    }
+
+    // @todo remove handling of deprecatedSetting two versions after 6.2
+    if (
+            isset($extbaseFrameworkConfiguration['view'][$deprecatedSetting]) && strlen($extbaseFrameworkConfiguration['view'][$deprecatedSetting]) > 0
+    ) {
+      $values[] = $extbaseFrameworkConfiguration['view'][$deprecatedSetting];
+    }
+
+    return $values;
+  }
+
+  public function initializeView() {
+    parent::initializeView();
+
+    // Resolve paths
+    /* @var $configurationManager \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface */
+    $configurationManager = $this->objectManager->get('TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface');
+    $extbaseFrameworkConfiguration = $configurationManager->getConfiguration(
+            \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
+            $this->controllerContext->getRequest()->getControllerExtensionName(),
+            $this->controllerContext->getRequest()->getPluginName()
+    );
+
+    $paths = array('template', 'layout', 'partial');
+    foreach ($paths as $path) {
+      $viewFunctionName = 'set' . \ucfirst($path) . 'RootPaths';
+      $deprecatedSetting = $path . 'RootPath';
+      $setting = $path . 'RootPaths';
+      $parameter = $this->getViewProperty($extbaseFrameworkConfiguration, $setting, $deprecatedSetting);
+      // no need to bother if there is nothing to set
+      if ($parameter) {
+        $this->$viewFunctionName($parameter);
+      }
+    }
+
+    $settingService = $this->objectManager->get('PAGEmachine\Hairu\Service\SettingService');
+    $this->assign('settings', $settingService->getSettings());
+  }
+
+  /**
+   * Sets the format of the current request (default format is "html")
+   *
+   * @param string $format
+   * @return void
+   */
+  public function setFormat($format) {
+    $this->controllerContext->getRequest()->setFormat($format);
+  }
+
+  /**
+   * Returns the format of the current request (defaults is "html")
+   *
+   * @return string $format
+   */
+  public function getFormat() {
+    return $this->controllerContext->getRequest()->getFormat();
+  }
+
+  /**
+   * Returns the UriBuilder used by this view
+   *
+   * @return \TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder
+   */
+  public function getUriBuilder() {
+    return $this->controllerContext->getUriBuilder();
+  }
+
+}

--- a/Classes/Service/PasswordResetService.php
+++ b/Classes/Service/PasswordResetService.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace PAGEmachine\Hairu\Service;
+
+/* * *************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Philipp Kerling <pkerling@casix.org>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @api
+ */
+class PasswordResetService implements \TYPO3\CMS\Core\SingletonInterface {
+
+  /**
+   * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface
+   * @inject
+   */
+  protected $objectManager;
+
+  /**
+   * @var \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
+   */
+  protected $tokenCache;
+
+  /**
+   * @var \TYPO3\CMS\Extbase\Security\Cryptography\HashService
+   * @inject
+   */
+  protected $hashService;
+
+  /**
+   * @var \PAGEmachine\Hairu\Service\SettingService
+   * @inject
+   */
+  protected $settingService;
+
+  /**
+   * @param \TYPO3\CMS\Core\Cache\CacheManager $cacheManager
+   * @return void
+   */
+  public function injectCacheManager(\TYPO3\CMS\Core\Cache\CacheManager $cacheManager) {
+    $this->tokenCache = $cacheManager->getCache('hairu_token');
+  }
+
+  public function generatePasswordResetHash(\TYPO3\CMS\Extbase\Domain\Model\FrontendUser $user) {
+    $tokenLifetime = $this->settingService->getSettingValue('passwordReset.token.lifetime');
+    $hash = \md5(GeneralUtility::generateRandomBytes(64));
+    $token = array(
+      'uid' => $user->getUid(),
+      'hmac' => $this->hashService->generateHmac($user->getPassword()),
+    );
+
+    // Remove possibly existing reset tokens and store new one
+    $this->tokenCache->flushByTag($user->getUid());
+    $this->tokenCache->set($hash, $token, array($user->getUid()), $tokenLifetime);
+
+    return $hash;
+  }
+
+  public function sendMail(\TYPO3\CMS\Extbase\Domain\Model\FrontendUser $user, $hash, $templateAction = 'passwordResetMail') {
+    /* @var $view \PAGEmachine\Hairu\Mvc\View\StandaloneView */
+    $view = $this->objectManager->get('PAGEmachine\Hairu\Mvc\View\StandaloneView');
+    $view->initializeView();
+    /*if (NULL !== $overrideTemplatePath) {
+      $templateRootPaths = $view->getTemplateRootPaths();
+      array_unshift($templateRootPaths, $overrideTemplatePath);
+      $view->setTemplateRootPaths($templateRootPaths);
+    }*/
+
+    $hashUri = $view->getUriBuilder()->reset()
+      ->setTargetPageUid($this->settingService->getSettingValue('passwordReset.page'))
+      ->setUseCacheHash(FALSE)
+      ->setCreateAbsoluteUri(TRUE)
+      ->uriFor('showPasswordResetForm', array(
+        'hash' => $hash,
+      ));
+    $tokenLifetime = $this->settingService->getSettingValue('passwordReset.token.lifetime');
+    $expiryDate = new \DateTime(sprintf('now + %d seconds', $tokenLifetime));
+    $view->assignMultiple(array(
+      'user' => $user,
+      'hash' => $hash, // Allow for custom URI in Fluid
+      'hashUri' => $hashUri,
+      'expiryDate' => $expiryDate,
+    ));
+
+    /* @var $message \TYPO3\CMS\Core\Mail\MailMessage */
+    $message = $this->objectManager->get('TYPO3\CMS\Core\Mail\MailMessage');
+    $message
+      ->setFrom($this->settingService->getSettingValue('passwordReset.mail.from'))
+      ->setTo($user->getEmail())
+      ->setSubject($this->settingService->getSettingValue('passwordReset.mail.subject'));
+
+    $view->setFormat('txt');
+    $message->setBody($view->render($templateAction), 'text/plain');
+
+    if ($this->settingService->getSettingValue('passwordReset.mail.html')) {
+      $view->setFormat('html');
+      $message->addPart($view->render($templateAction), 'text/html');
+    }
+
+    return ((integer) 1 === $message->send());
+  }
+
+}

--- a/Classes/Service/SettingService.php
+++ b/Classes/Service/SettingService.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace PAGEmachine\Hairu\Service;
+
+use TYPO3\CMS\Core\Utility\MailUtility;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+
+class SettingService implements \TYPO3\CMS\Core\SingletonInterface {
+
+  /**
+   * @var array
+   */
+  protected $settings;
+
+  /**
+   * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
+   */
+  protected $configurationManager;
+
+  /**
+   * @param \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager
+   * @return void
+   */
+  public function injectConfigurationManager(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager) {
+    $this->configurationManager = $configurationManager;
+    $originalSettings = $this->configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS, 'Hairu', 'Auth');
+
+    $defaultSettings = array(
+      'dateFormat' => $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'],
+      'login' => array(
+        'page' => $this->getFrontendController()->id,
+      ),
+      'passwordReset' => array(
+        'loginOnSuccess' => FALSE,
+        'mail' => array(
+          'from' => MailUtility::getSystemFromAddress(),
+          'subject' => 'Password reset request',
+          'html' => FALSE
+        ),
+        'page' => $this->getFrontendController()->id,
+        'token' => array(
+          'lifetime' => 86400, // 1 day
+        ),
+      ),
+    );
+
+    $settings = $defaultSettings;
+    ArrayUtility::mergeRecursiveWithOverrule($settings, $originalSettings, TRUE, FALSE);
+    $this->settings = $settings;
+  }
+
+  /**
+   * @return array
+   */
+  public function getSettings() {
+    return $this->settings;
+  }
+
+  /**
+   * Shorthand helper for getting setting values with optional default values
+   *
+   * Any setting value is automatically processed via stdWrap if configured.
+   *
+   * @param string $settingPath Path to the setting, e.g. "foo.bar.qux"
+   * @param mixed $defaultValue Default value if no value is set
+   * @return mixed
+   */
+  public function getSettingValue($settingPath, $defaultValue = NULL) {
+
+    $value = ObjectAccess::getPropertyPath($this->settings, $settingPath);
+    $stdWrapConfiguration = ObjectAccess::getPropertyPath($this->settings, $settingPath . '.stdWrap');
+
+    if ($stdWrapConfiguration !== NULL) {
+      $value = $this->getFrontendController()->cObj->stdWrap($value, $stdWrapConfiguration);
+    }
+
+    // Change type of value to type of default value if possible
+    if (!empty($value) && $defaultValue !== NULL) {
+      settype($value, gettype($defaultValue));
+    }
+
+    $value = !empty($value) ? $value : $defaultValue;
+
+    return $value;
+  }
+
+  public function setSettingValue($settingPath, $settingValue) {
+    $this->settings = ArrayUtility::setValueByPath($this->settings, $settingPath, $settingValue, '.');
+  }
+
+  /**
+   * @return \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
+   */
+  protected function getFrontendController() {
+    return $GLOBALS['TSFE'];
+  }
+
+}

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -18,11 +18,11 @@ plugin.tx_hairu {
 
   settings {
     // cat=plugin.tx_hairu//dateFormat; type=string; label=Date format: Format for date output (PHP date/strftime), value of TYPO3_CONF_VARS/SYS/ddmmyy if empty
-    dateFormat = 
+    dateFormat =
 
     login {
       // cat=plugin.tx_hairu/login/page; type=int+; label=Login page ID: Page where visitors can log in, current page if empty
-      page = 
+      page =
     }
 
     passwordReset {
@@ -37,8 +37,10 @@ plugin.tx_hairu {
       mail {
         // cat=plugin.tx_hairu/reset/mail.subject; type=string; label=Mail subject: Subject for the password reset mail
         subject = Password reset request
-        // cat=plugin.tx_hairu/reset/mail.subject; type=string; label=Mail from: Sender for the password reset mail, system from address if empty
-        from = 
+        // cat=plugin.tx_hairu/reset/mail.from; type=string; label=Mail from: Sender for the password reset mail, system from address if empty
+        from =
+        // cat=plugin.tx_hairu/reset/mail.html; type=boolean; label=Send the reset mail including HTML content?
+        html = 0
       }
 
       // cat=plugin.tx_hairu/reset/loginOnSuccess; type=boolean; label=Login on success: Whether to automatically log in users after successful password reset

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -46,6 +46,7 @@ plugin.tx_hairu {
       mail {
         subject = {$plugin.tx_hairu.settings.passwordReset.mail.subject}
         from = {$plugin.tx_hairu.settings.passwordReset.mail.from}
+        html = {$plugin.tx_hairu.settings.passwordReset.mail.html}
       }
 
       loginOnSuccess = {$plugin.tx_hairu.settings.passwordReset.loginOnSuccess}


### PR DESCRIPTION
On a website I'm working on, users get mass-imported via a custom extension and should then get an e-mail so they can set their passwords themselves on the page. I thought that it would be very nice if I could use the password reset procedure already implemented in Hairu to avoid duplicating code.
I have refactored the handling of password resets to a new service class which also made it necessary to move settings handling used by this new service and the original controller to yet another service.
It is, unfortunately, very complicated to render standalone templates in a different extension/controller with extbase/fluid. The StandaloneView in the patch does make it possible, but should probably considered a dirty hack.

The code is tested but not really documented. I would ask you to take a look and tell me your thoughts on this. I'll polish it up if you consider integrating it into Hairu.
