### PR TITLE
[FEATURE] Add RSA encryption to password reset for TYPO3 7.4

### DIFF
--- a/Classes/Controller/AuthenticationController.php
+++ b/Classes/Controller/AuthenticationController.php
@@ -235,6 +235,16 @@ class AuthenticationController extends ActionController {
         $this->addLocalizedFlashMessage('resetPassword.hints', NULL, FlashMessage::INFO);
 
         $this->view->assign('hash', $hash);
+
+        if (class_exists('TYPO3\\CMS\\Rsaauth\\RsaEncryptionEncoder')) {
+
+          $rsaEncryptionEncoder = $this->objectManager->get('TYPO3\\CMS\\Rsaauth\\RsaEncryptionEncoder');
+
+          if ($rsaEncryptionEncoder->isAvailable()) {
+
+            $rsaEncryptionEncoder->enableRsaEncryption();
+          }
+        }
       } else {
 
         $this->addLocalizedFlashMessage('resetPassword.failed.invalid', NULL, FlashMessage::ERROR);
@@ -330,6 +340,22 @@ class AuthenticationController extends ActionController {
    * @return void
    */
   protected function initializeCompletePasswordResetAction() {
+
+    if (class_exists('TYPO3\\CMS\\Rsaauth\\RsaEncryptionDecoder')) {
+
+      $rsaEncryptionDecoder = $this->objectManager->get('TYPO3\\CMS\\Rsaauth\\RsaEncryptionDecoder');
+
+      if ($rsaEncryptionDecoder->isAvailable()) {
+
+        $arguments = $rsaEncryptionDecoder->decrypt(array(
+          'password' => $this->request->getArgument('password'),
+          'passwordRepeat' => $this->request->getArgument('passwordRepeat'),
+        ));
+
+        $this->request->setArgument('password', $arguments['password']);
+        $this->request->setArgument('passwordRepeat', $arguments['passwordRepeat']);
+      }
+    }
 
     // Password repeat validation needs to be added manually here to access the password value
     $passwordRepeatArgumentValidator = $this->arguments->getArgument('passwordRepeat')->getValidator();

--- a/Resources/Private/Templates/Authentication/ShowPasswordResetForm.html
+++ b/Resources/Private/Templates/Authentication/ShowPasswordResetForm.html
@@ -31,14 +31,16 @@
         fieldName: 'password',
         fieldType: 'password',
         translationKey: 'password',
-        defaultLabel: 'Password'
+        defaultLabel: 'Password',
+        additionalAttributes: {data-rsa-encryption: ''}
       }"/>
 
       <f:render partial="Form/TextField" arguments="{
         fieldName: 'passwordRepeat',
         fieldType: 'password',
         translationKey: 'passwordRepeat',
-        defaultLabel: 'Repeat password'
+        defaultLabel: 'Repeat password',
+        additionalAttributes: {data-rsa-encryption: ''}
       }"/>
 
       <f:render partial="Form/SubmitButton" arguments="{


### PR DESCRIPTION
This makes use of the new RSA encryption API introduced with
TYPO3 7.4 to protect passwords submitted in our reset form.

Fixes #4