### PR TITLE
[BUGFIX] Don't require typo3/cms package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
         - bin/xmllint --pattern "*.xlf*,svg" Resources
     - php: 7.1
       env: Codestyle
+      install:
+        - composer install
       script:
         - bin/phpcs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $HOME/.composer/cache
 
 install:
-  - composer install
+  - composer require typo3/cms="$TYPO3_VERSION"
 
 script:
   - bin/parallel-lint --exclude bin --exclude vendor .
@@ -15,9 +15,16 @@ script:
 jobs:
   include:
     - php: 5.6
+      env: TYPO3_VERSION=^7.6
     - php: 7.0
+      env: TYPO3_VERSION=^7.6
+    - php: 7.0
+      env: TYPO3_VERSION=^8.7
+      
     - php: 7.1
       env: Other lints
+      install:
+        - composer install
       script:
         - bin/typoscript-lint
         - bin/xmllint --pattern "*.xlf*,svg" Resources

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
   "type": "typo3-cms-extension",
   "require": {
     "php": "^5.6 || ^7.0",
-    "typo3/cms": "^7.6 || ^8.7",
     "typo3/cms-core": "^7.6 || ^8.7",
     "typo3/cms-extbase": "^7.6 || ^8.7",
     "typo3/cms-fluid": "^7.6 || ^8.7",


### PR DESCRIPTION
We must not require the whole typo3/cms package for production
since this basically prevents installation of selected TYPO3 packages.