### PR TITLE
[BUGFIX] proper TypoScriptService namespace usage

### DIFF
--- a/Classes/Controller/AuthenticationController.php
+++ b/Classes/Controller/AuthenticationController.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
-use TYPO3\CMS\Extbase\TypoScript\TypoScriptService;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Rsaauth\RsaEncryptionEncoder;
 
 /**


### PR DESCRIPTION
Controller would throw ClassNotFound exception.
Wrong class namespace has been used.

Also, this change was deployed with TYPO3 8.7 (change #78650). That means it will break 7.6.
Extbase has class alias set to ```TYPO3\CMS\Extbase\Service\TypoScriptService```.