### PR TITLE
TypoScriptService class moved from Extbase to Core

### DIFF
--- a/Classes/Controller/AuthenticationController.php
+++ b/Classes/Controller/AuthenticationController.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
-use TYPO3\CMS\Extbase\TypoScript\TypoScriptService;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Rsaauth\RsaEncryptionEncoder;
 
 /**


### PR DESCRIPTION
ChangeLog v8 » 8.7 Changes 
 https://docs.typo3.org/typo3cms/extensions/core/Changelog/8.7/Important-78650-TypoScriptServiceClassMovedFromExtbaseToCore.html#important-78650-typoscriptservice-class-moved-from-extbase-to-core