### PR TITLE
[BUGFIX] Fix missing escaping of form validation errors

### DIFF
--- a/Resources/Private/Partials/Form/ValidationErrors.html
+++ b/Resources/Private/Partials/Form/ValidationErrors.html
@@ -7,7 +7,7 @@
       <ul class="errors">
         <f:for each="{validationResults.flattenedErrors}" as="errors" key="propertyPath">
           <li>
-            <f:translate key="{propertyPath}">{propertyPath}</f:translate>: {errors.0}
+            <f:translate key="{propertyPath}">{propertyPath}</f:translate>: {errors.0.message}
           </li>
         </f:for>
       </ul>


### PR DESCRIPTION
On Typo3 7.6, I encountered the problem that rendering the message directly via the object bypasses the HTML escaping normally done by fluid. Using the message string works correctly. I'm not sure whether this is still a problem on T3 8 or 9, though.