### PR TITLE
Support name in password reset mail "From"

### DIFF
--- a/Classes/Controller/AuthenticationController.php
+++ b/Classes/Controller/AuthenticationController.php
@@ -299,7 +299,7 @@ class AuthenticationController extends AbstractController
 
             $message = $this->objectManager->get(MailMessage::class);
             $message
-                ->setFrom($this->getSettingValue('passwordReset.mail.from'))
+                ->setFrom(MailUtility::parseAddresses($this->getSettingValue('passwordReset.mail.from')))
                 ->setTo($userEmail)
                 ->setSubject($this->getSettingValue('passwordReset.mail.subject'));
 


### PR DESCRIPTION
This setting can now look like this:

* `Foo Bar <foo@example.org>`
* `"Special.Characters.Need.Quotes" <special@example.com>`

Fixes #53