### PR TITLE
Move PageTSconfig registration to ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -46,6 +46,11 @@ if (empty($GLOBALS['TYPO3_CONF_VARS']['LOG']['PAGEmachine']['Hairu']['writerConf
     ];
 }
 
+// PageTS extensions
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+    '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:hairu/Configuration/TSconfig/page.tsconfig">'
+);
+
 (function () {
     // New content element wizard icon
     $icons = [

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,7 +1,0 @@
-<?php
-defined('TYPO3_MODE') or die();
-
-// PageTS extensions
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-    '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:hairu/Configuration/TSconfig/page.tsconfig">'
-);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,6 @@
   <file>Configuration/TCA</file>
   <file>ext_emconf.php</file>
   <file>ext_localconf.php</file>
-  <file>ext_tables.php</file>
 
   <rule ref="PSR2">
     <exclude name="Generic.Files.LineLength"/>


### PR DESCRIPTION
We are not able to remove the forms from the newContentElementWizard in our site package extension because the hairu TSconfig is incorrectly included via ext_tables.php.

It should be included via ext_localconf.php as the PHPDoc of `ExtensionManagementUtility::addPageTSConfig` states.