### PR TITLE
[SECURITY] Use signed storage PID during frontend authentication

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -19,7 +19,9 @@ use PAGEmachine\Hairu\Domain\Repository\FrontendUserRepository;
 use PAGEmachine\Hairu\Domain\Service\AuthenticationService;
 use PAGEmachine\Hairu\Domain\Service\PasswordService;
 use PAGEmachine\Hairu\Mvc\Controller\ActionController;
+use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -85,6 +87,12 @@ abstract class AbstractController extends ActionController
             ($messageTitle != '' ? LocalizationUtility::translate($messageTitle, $this->request->getControllerExtensionName(), $translationArguments) : ''),
             $severity
         );
+    }
+
+    protected function shallEnforceLoginSigning(): bool
+    {
+        return GeneralUtility::makeInstance(Features::class)
+            ->isFeatureEnabled('security.frontend.enforceLoginSigning');
     }
 
     /**

--- a/Classes/Controller/AuthenticationController.php
+++ b/Classes/Controller/AuthenticationController.php
@@ -31,6 +31,7 @@ use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
+use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Rsaauth\RsaEncryptionDecoder;
 use TYPO3\CMS\Rsaauth\RsaEncryptionEncoder;
@@ -153,8 +154,19 @@ class AuthenticationController extends AbstractController
 
         $view->assignMultiple([
             'formData' => $this->request->getArgument('formData'),
-            'storagePid' => $frameworkConfiguration['persistence']['storagePid'],
+            'storagePid' => $this->getSignedStorageFolders($frameworkConfiguration['persistence']['storagePid']),
         ]);
+    }
+
+    protected function getSignedStorageFolders(string $storagePidList): string
+    {
+        $pidList = implode(',', GeneralUtility::intExplode(',', $storagePidList, true));
+
+        return sprintf(
+            '%s@%s',
+            $pidList,
+            GeneralUtility::hmac($pidList, FrontendUserAuthentication::class)
+        );
     }
 
     /**

--- a/Classes/Controller/AuthenticationController.php
+++ b/Classes/Controller/AuthenticationController.php
@@ -151,10 +151,11 @@ class AuthenticationController extends AbstractController
     protected function initializeView(ViewInterface $view)
     {
         $frameworkConfiguration = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
+        $storagePidList = $frameworkConfiguration['persistence']['storagePid'];
 
         $view->assignMultiple([
             'formData' => $this->request->getArgument('formData'),
-            'storagePid' => $this->getSignedStorageFolders($frameworkConfiguration['persistence']['storagePid']),
+            'storagePid' => $this->shallEnforceLoginSigning() ? $this->getSignedStorageFolders($storagePidList) : $storagePidList,
         ]);
     }
 


### PR DESCRIPTION
Make the extension working with security fix of TYPO3 v10.4.33 and respect the new "security.frontend.enforceLoginSigning" feature flag (come with TYPO3 v10.4.34)

* TYPO3 security commit https://github.com/typo3/typo3/commit/96ed3e627f
* TYPO3 feature flag commit https://github.com/typo3/typo3/commit/0fe0322528

fixes #104 