### PR TITLE
Abandon package in favor of typo3/cms-felogin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "abandoned": "typo3/cms-felogin",
     "name": "pagemachine/hairu",
     "description": "Flexible login/logout form based on Extbase/Fluid",
     "license": "GPL-3.0-or-later",


### PR DESCRIPTION
TYPO3 CMS Frontend Login shipped an optional Extbase/Fluid plugin with TYPO3v10 which was developed further over time. With TYPO3v12 password policies were added which was the last benefit of Hairu, thus the latter is abandoned now.

See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.2/Feature-88102-FrontendLoginViaFluidAndExtbase.html And https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Feature-97390-UsePasswordPolicyForPasswordResetInExtfelogin.html